### PR TITLE
Add helper to extract Paystack meta object

### DIFF
--- a/paystackease/helpers/meta.py
+++ b/paystackease/helpers/meta.py
@@ -1,0 +1,21 @@
+"""
+Helpers for handling Paystack meta objects.
+"""
+
+def get_meta(response: dict) -> dict:
+    """
+    Extract the meta object from a Paystack API response.
+
+    :param response: Full API response dictionary
+    :return: Meta object if present, else empty dict
+    """
+    if not isinstance(response, dict):
+        return {}
+      
+    meta = response.get("meta")
+
+    if isinstance(meta, dict):
+        return meta
+
+
+    return response.get("meta", {})


### PR DESCRIPTION
While reviewing the Paystack API documentation, I noticed that many responses include a meta object, but the library does not currently expose it.

This PR adds a small helper function to safely extract the meta object from API responses without affecting existing behavior.
